### PR TITLE
Error: cannot find global object JPGCodestream

### DIFF
--- a/jp2file.py
+++ b/jp2file.py
@@ -2066,6 +2066,7 @@ def superbox_hook(box,id,length):
                 jxr = JXRCodestream(box.infile,1)
                 jxr.parse()
             elif ord(type[0]) == 0xff and ord(type[1]) == 0xd8:
+                from jpgcodestream import JPGCodestream
                 cs = JPGCodestream(indent = box.indent + 1, hook = superbox_hook)
                 cs.stream_parse(box.infile,box.offset)
             elif ord(type[0]) == 0xff and ord(type[1]) == 0x10:


### PR DESCRIPTION
Hi @lrosenthol ,

I am writing to report a bug in the codestream-parser code base. When Python script reaches line #2069, it complains about the missing class `JPGCodestream`.

What is the best way to import such class in the header of `jp2file.py`?

Regards,
Antony